### PR TITLE
fixed bug in fetch

### DIFF
--- a/libraries/sql/sql/sqlite.hh
+++ b/libraries/sql/sql/sqlite.hh
@@ -109,7 +109,9 @@ struct sqlite_statement {
     if (empty())
       return false;
     row_to_metamap(o);
-    ready_for_reading_ = false;
+    last_step_ret_ = sqlite3_step(stmt_);
+    if (last_step_ret_ != SQLITE_ROW and last_step_ret_ != SQLITE_DONE)
+      throw std::runtime_error(sqlite3_errstr(last_step_ret_));
     return true;
   }
 
@@ -121,7 +123,9 @@ struct sqlite_statement {
     if (empty())
       return false;
     this->read_column(0, o);
-    ready_for_reading_ = false;
+    last_step_ret_ = sqlite3_step(stmt_);
+    if (last_step_ret_ != SQLITE_ROW and last_step_ret_ != SQLITE_DONE)
+      throw std::runtime_error(sqlite3_errstr(last_step_ret_));
     return true;
   }
 


### PR DESCRIPTION
the fetch function was buggy due to the reset of the "ready_for_reading_" flag. -> this reinitialized the SQL request by forcing the call to the operator () at next fetch call.

I just use SQLite, I didn't check other RDBMS...