### PR TITLE
Feature: Optional SSL CTX ciphersuite selection

### DIFF
--- a/libraries/http_backend/README.md
+++ b/libraries/http_backend/README.md
@@ -57,6 +57,9 @@ int main() {
 
   // Or start a https server:
   http_serve(api, 443, s::ssl_key = "./server.key", s::ssl_certificate = "./server.crt");
+
+  // Optionally start a https with your ciphersuite
+  http_serve(api, 443, s::ssl_key = "./server.key", s::ssl_certificate = "./server.crt", s::ssl_ciphers = "ALL:!NULL");
 }
 ```
 

--- a/libraries/http_backend/http_backend/http_serve.hh
+++ b/libraries/http_backend/http_backend/http_serve.hh
@@ -664,9 +664,10 @@ auto http_serve(api<http_request, http_response> api, int port, O... opts) {
       static_assert(has_key(options, s::ssl_certificate), "You need to provide both the ssl_certificate option and the ssl_key option.");
       std::string ssl_key = options.ssl_key;
       std::string ssl_cert = options.ssl_certificate;
+      std::string ssl_ciphers = options.ssl_ciphers;
       start_tcp_server(port, SOCK_STREAM, nthreads,
                        http_async_impl::make_http_processor(std::move(handler)),
-                       ssl_key, ssl_cert);
+                       ssl_key, ssl_cert, ssl_ciphers);
     }
     else
       start_tcp_server(port, SOCK_STREAM, nthreads,

--- a/libraries/http_backend/http_backend/http_serve.hh
+++ b/libraries/http_backend/http_backend/http_serve.hh
@@ -664,7 +664,11 @@ auto http_serve(api<http_request, http_response> api, int port, O... opts) {
       static_assert(has_key(options, s::ssl_certificate), "You need to provide both the ssl_certificate option and the ssl_key option.");
       std::string ssl_key = options.ssl_key;
       std::string ssl_cert = options.ssl_certificate;
-      std::string ssl_ciphers = options.ssl_ciphers;
+      std::string ssl_ciphers = "";
+      if constexpr (has_key(options, s::ssl_ciphers))
+      {
+        ssl_ciphers = options.ssl_ciphers;
+      }
       start_tcp_server(port, SOCK_STREAM, nthreads,
                        http_async_impl::make_http_processor(std::move(handler)),
                        ssl_key, ssl_cert, ssl_ciphers);

--- a/libraries/http_backend/http_backend/ssl_context.hh
+++ b/libraries/http_backend/http_backend/ssl_context.hh
@@ -19,7 +19,8 @@ struct ssl_context {
       SSL_CTX_free(ctx);
   }
 
-  ssl_context(const std::string& key_path, const std::string& cert_path) {
+  ssl_context(const std::string& key_path, const std::string& cert_path, 
+              const std::string& ciphers) {
     if (!openssl_initialized) {
       SSL_load_error_strings();
       OpenSSL_add_ssl_algorithms();
@@ -38,6 +39,12 @@ struct ssl_context {
     }
 
     SSL_CTX_set_ecdh_auto(ctx, 1);
+
+    /* Set the ciphersuite */
+    if (ciphers.c_str().size() && SSL_CTX_set_cipher_list(ctx, ciphers.c_str()) <= 0) {
+      ERR_print_errors_fp(stderr);
+      exit(EXIT_FAILURE);
+    }
 
     /* Set the key and cert */
     if (SSL_CTX_use_certificate_file(ctx, cert_path.c_str(), SSL_FILETYPE_PEM) <= 0) {

--- a/libraries/http_backend/http_backend/ssl_context.hh
+++ b/libraries/http_backend/http_backend/ssl_context.hh
@@ -40,8 +40,8 @@ struct ssl_context {
 
     SSL_CTX_set_ecdh_auto(ctx, 1);
 
-    /* Set the ciphersuite */
-    if (ciphers.c_str().size() && SSL_CTX_set_cipher_list(ctx, ciphers.c_str()) <= 0) {
+    /* Set the ciphersuite if provided */
+    if (ciphers.size() && SSL_CTX_set_cipher_list(ctx, ciphers.c_str()) <= 0) {
       ERR_print_errors_fp(stderr);
       exit(EXIT_FAILURE);
     }

--- a/libraries/http_backend/http_backend/symbols.hh
+++ b/libraries/http_backend/http_backend/symbols.hh
@@ -99,6 +99,11 @@
 #define LI_SYMBOL_ssl_key
     LI_SYMBOL(ssl_key)
 #endif
+        
+#ifndef LI_SYMBOL_ssl_ciphers
+#define LI_SYMBOL_ssl_ciphers
+    LI_SYMBOL(ssl_ciphers)
+#endif
 
 #ifndef LI_SYMBOL_update_secret_key
 #define LI_SYMBOL_update_secret_key

--- a/libraries/http_backend/http_backend/tcp_server.hh
+++ b/libraries/http_backend/http_backend/tcp_server.hh
@@ -371,7 +371,8 @@ void async_fiber_context::epoll_mod(int fd, int flags) { reactor->epoll_mod(fd, 
 
 template <typename H>
 void start_tcp_server(int port, int socktype, int nthreads, H conn_handler,
-                      std::string ssl_key_path = "", std::string ssl_cert_path = "") {
+                      std::string ssl_key_path = "", std::string ssl_cert_path = "",
+                      std::string ssl_ciphers = "") {
 
   struct sigaction act;
   memset(&act, 0, sizeof(act));
@@ -387,7 +388,7 @@ void start_tcp_server(int port, int socktype, int nthreads, H conn_handler,
     ths.push_back(std::thread([&] {
       async_reactor reactor;
       if (ssl_cert_path.size()) // Initialize the SSL/TLS context.
-        reactor.ssl_ctx = std::make_unique<ssl_context>(ssl_key_path, ssl_cert_path);
+        reactor.ssl_ctx = std::make_unique<ssl_context>(ssl_key_path, ssl_cert_path, ssl_ciphers);
       reactor.event_loop(server_fd, conn_handler);
     }));
 

--- a/libraries/http_backend/tests/https.cc
+++ b/libraries/http_backend/tests/https.cc
@@ -11,6 +11,6 @@ int main() {
   };
 
   system("openssl req -new -newkey rsa:4096 -x509 -sha256 -days 365 -nodes -out ./server.crt -keyout ./server.key -subj \"/CN=localhost\"");
-  http_serve(my_api, 12334, s::non_blocking, s::ssl_key = "./server.key", s::ssl_certificate = "./server.crt");
+  http_serve(my_api, 12334, s::non_blocking, s::ssl_key = "./server.key", s::ssl_certificate = "./server.crt", s::ssl_ciphers = "ALL:!NULL");
   assert(http_get("https://localhost:12334/hello_world", s::disable_check_certificate).body == "hello world.");
 }

--- a/libraries/http_backend/tests/symbols.hh
+++ b/libraries/http_backend/tests/symbols.hh
@@ -135,6 +135,11 @@
     LI_SYMBOL(ssl_key)
 #endif
 
+#ifndef LI_SYMBOL_ssl_ciphers
+#define LI_SYMBOL_ssl_ciphers
+    LI_SYMBOL(ssl_ciphers)
+#endif
+
 #ifndef LI_SYMBOL_test1
 #define LI_SYMBOL_test1
     LI_SYMBOL(test1)

--- a/single_headers/lithium.hh
+++ b/single_headers/lithium.hh
@@ -3210,6 +3210,11 @@ template <typename... P> auto http_delete(const std::string& url, P... params) {
     LI_SYMBOL(ssl_key)
 #endif
 
+#ifndef LI_SYMBOL_ssl_ciphers
+#define LI_SYMBOL_ssl_ciphers
+    LI_SYMBOL(ssl_ciphers)
+#endif
+
 #ifndef LI_SYMBOL_update_secret_key
 #define LI_SYMBOL_update_secret_key
     LI_SYMBOL(update_secret_key)
@@ -6242,7 +6247,8 @@ struct ssl_context {
       SSL_CTX_free(ctx);
   }
 
-  ssl_context(const std::string& key_path, const std::string& cert_path) {
+  ssl_context(const std::string& key_path, const std::string& cert_path,
+              const std::string& ciphers) {
     if (!openssl_initialized) {
       SSL_load_error_strings();
       OpenSSL_add_ssl_algorithms();
@@ -6261,6 +6267,12 @@ struct ssl_context {
     }
 
     SSL_CTX_set_ecdh_auto(ctx, 1);
+
+    /* Set the ciphersuite if provided */
+    if (ciphers.size() && SSL_CTX_set_cipher_list(ctx, ciphers.c_str()) <= 0) {
+      ERR_print_errors_fp(stderr);
+      exit(EXIT_FAILURE);
+    }
 
     /* Set the key and cert */
     if (SSL_CTX_use_certificate_file(ctx, cert_path.c_str(), SSL_FILETYPE_PEM) <= 0) {
@@ -6632,7 +6644,8 @@ void async_fiber_context::epoll_mod(int fd, int flags) { reactor->epoll_mod(fd, 
 
 template <typename H>
 void start_tcp_server(int port, int socktype, int nthreads, H conn_handler,
-                      std::string ssl_key_path = "", std::string ssl_cert_path = "") {
+                      std::string ssl_key_path = "", std::string ssl_cert_path = "",
+                      std::string ssl_ciphers = "") {
 
   struct sigaction act;
   memset(&act, 0, sizeof(act));
@@ -6648,7 +6661,7 @@ void start_tcp_server(int port, int socktype, int nthreads, H conn_handler,
     ths.push_back(std::thread([&] {
       async_reactor reactor;
       if (ssl_cert_path.size()) // Initialize the SSL/TLS context.
-        reactor.ssl_ctx = std::make_unique<ssl_context>(ssl_key_path, ssl_cert_path);
+        reactor.ssl_ctx = std::make_unique<ssl_context>(ssl_key_path, ssl_cert_path, ssl_ciphers);
       reactor.event_loop(server_fd, conn_handler);
     }));
 
@@ -7841,9 +7854,10 @@ auto http_serve(api<http_request, http_response> api, int port, O... opts) {
       static_assert(has_key(options, s::ssl_certificate), "You need to provide both the ssl_certificate option and the ssl_key option.");
       std::string ssl_key = options.ssl_key;
       std::string ssl_cert = options.ssl_certificate;
+      std::string ssl_ciphers = options.ssl_ciphers;
       start_tcp_server(port, SOCK_STREAM, nthreads,
                        http_async_impl::make_http_processor(std::move(handler)),
-                       ssl_key, ssl_cert);
+                       ssl_key, ssl_cert, ssl_ciphers);
     }
     else
       start_tcp_server(port, SOCK_STREAM, nthreads,

--- a/single_headers/lithium.hh
+++ b/single_headers/lithium.hh
@@ -7854,7 +7854,11 @@ auto http_serve(api<http_request, http_response> api, int port, O... opts) {
       static_assert(has_key(options, s::ssl_certificate), "You need to provide both the ssl_certificate option and the ssl_key option.");
       std::string ssl_key = options.ssl_key;
       std::string ssl_cert = options.ssl_certificate;
-      std::string ssl_ciphers = options.ssl_ciphers;
+      std::string ssl_ciphers = "";
+      if constexpr (has_key(options, s::ssl_ciphers))
+      {
+        ssl_ciphers = options.ssl_ciphers;
+      }
       start_tcp_server(port, SOCK_STREAM, nthreads,
                        http_async_impl::make_http_processor(std::move(handler)),
                        ssl_key, ssl_cert, ssl_ciphers);

--- a/single_headers/lithium_http_backend.hh
+++ b/single_headers/lithium_http_backend.hh
@@ -5034,7 +5034,11 @@ auto http_serve(api<http_request, http_response> api, int port, O... opts) {
       static_assert(has_key(options, s::ssl_certificate), "You need to provide both the ssl_certificate option and the ssl_key option.");
       std::string ssl_key = options.ssl_key;
       std::string ssl_cert = options.ssl_certificate;
-      std::string ssl_ciphers = options.ssl_ciphers;
+      std::string ssl_ciphers = "";
+      if constexpr (has_key(options, s::ssl_ciphers))
+      {
+        ssl_ciphers = options.ssl_ciphers;
+      }
       start_tcp_server(port, SOCK_STREAM, nthreads,
                        http_async_impl::make_http_processor(std::move(handler)),
                        ssl_key, ssl_cert, ssl_ciphers);

--- a/single_headers/lithium_mysql.hh
+++ b/single_headers/lithium_mysql.hh
@@ -2455,6 +2455,11 @@ inline auto mysql_database_impl::scoped_connection(Y& fiber,
     LI_SYMBOL(ssl_certificate)
 #endif
 
+#ifndef LI_SYMBOL_ssl_ciphers
+#define LI_SYMBOL_ssl_ciphers
+    LI_SYMBOL(ssl_ciphers)
+#endif
+
 #ifndef LI_SYMBOL_ssl_key
 #define LI_SYMBOL_ssl_key
     LI_SYMBOL(ssl_key)

--- a/single_headers/lithium_pgsql.hh
+++ b/single_headers/lithium_pgsql.hh
@@ -2133,6 +2133,11 @@ typedef sql_database<pgsql_database_impl> pgsql_database;
     LI_SYMBOL(ssl_key)
 #endif
 
+#ifndef LI_SYMBOL_ssl_ciphers
+#define LI_SYMBOL_ssl_ciphers
+    LI_SYMBOL(ssl_ciphers)
+#endif
+
 #ifndef LI_SYMBOL_update_secret_key
 #define LI_SYMBOL_update_secret_key
     LI_SYMBOL(update_secret_key)

--- a/single_headers/lithium_sqlite.hh
+++ b/single_headers/lithium_sqlite.hh
@@ -1563,6 +1563,11 @@ struct sqlite_database {
     LI_SYMBOL(ssl_key)
 #endif
 
+#ifndef LI_SYMBOL_ssl_ciphers
+#define LI_SYMBOL_ssl_ciphers
+    LI_SYMBOL(ssl_ciphers)
+#endif
+
 #ifndef LI_SYMBOL_update_secret_key
 #define LI_SYMBOL_update_secret_key
     LI_SYMBOL(update_secret_key)


### PR DESCRIPTION
This PR introduces a feature for the new SSL http_backend.

Currently, the `ssl_context` inits OpenSSL with [OpenSSL_add_ssl_algorithms #L25](https://github.com/matt-42/lithium/blob/b8919d31ace31a394b063a256d27f2a6aa9c0bf8/libraries/http_backend/http_backend/ssl_context.hh#L25).

This is okay for non-production or internal environments but should be avoided in production,
mainly due to the lax ciphersuite selection performed by OpenSSL.

As stated in the official OpenSSL docs:

> WARNING
SSL_library_init() adds ciphers and digests used directly and indirectly by SSL/TLS. [...Source...](https://www.openssl.org/docs/man1.1.0/man3/OpenSSL_add_ssl_algorithms.html)

`OpenSSL_add_ssl_algorithms` is a synonym for `SSL_library_init()`.

In order to allow developers to select a ciphersuite of their choice, [`SSL_CTX_set_cipher_list`](https://www.openssl.org/docs/man1.1.0/man3/SSL_CTX_set_cipher_list.html) should be used.

This PR makes use of that function and (optionally) enables it by starting ``http_serve`` with the new ``s::ssl_ciphers`` symbol.

Example:

```c++
http_serve(api, 443, s::ssl_key = "./server.key", s::ssl_certificate = "./server.crt", s::ssl_ciphers = "ALL:!NULL");
````

To keep backward-compatibility and more freedom, this option is optional, and the ``http_serve`` signature can
remain as is:

```c++
http_serve(api, 443, s::ssl_key = "./server.key", s::ssl_certificate = "./server.crt");
````

An empty ciphersuite string will fallback to the default behaviour, that is skipping `SSL_CTX_set_cipher_list`.

Example:

```c++
http_serve(api, 443, s::ssl_key = "./server.key", s::ssl_certificate = "./server.crt", s::ssl_ciphers = "");
````

is the same as 

```c++
http_serve(api, 443, s::ssl_key = "./server.key", s::ssl_certificate = "./server.crt");
````

---

Compiled and tested with CLang 9 (LLVM 9) @ Ubuntu 18.04.4 LTS (bionic beaver)

---


I hope I was able to get the idea across.

Feel free to change, approve or dismiss this PR.

Great library and best regards,
Steve