### PR TITLE
Fix README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 The Lithium C++ Libraries ![Travis](https://travis-ci.com/matt-42/lithium.svg?branch=master) [![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.me/matthieugarrigues)
-
 ========================
 
 Lithium's goal is to ease the development of C++ high performance HTTP


### PR DESCRIPTION
This PR fixes a title in README is broken rendered on GitHub.

- Before

<img width="434" alt="スクリーンショット 2020-08-29 21 16 53" src="https://user-images.githubusercontent.com/823277/91636652-3b7a5900-ea3d-11ea-8a0d-f1a01db8e153.png">

- After

<img width="633" alt="スクリーンショット 2020-08-29 21 17 58" src="https://user-images.githubusercontent.com/823277/91636655-43d29400-ea3d-11ea-81d6-3d653d9321d1.png">
