### PR TITLE
Make `sys/sendfile.h` Linux Only

### DIFF
--- a/single_headers/lithium.hh
+++ b/single_headers/lithium.hh
@@ -61,7 +61,9 @@
 #include <sys/event.h>
 #endif
 #include <sys/mman.h>
+#if __linux__
 #include <sys/sendfile.h>
+#endif
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/types.h>

--- a/single_headers/lithium_http_server.hh
+++ b/single_headers/lithium_http_server.hh
@@ -50,7 +50,9 @@
 #include <sys/event.h>
 #endif
 #include <sys/mman.h>
+#if __linux__
 #include <sys/sendfile.h>
+#endif
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/types.h>

--- a/single_headers/make_single_headers.py
+++ b/single_headers/make_single_headers.py
@@ -8,7 +8,7 @@ from os.path import join
 
 WITH_LINE_DIRECTIVES = False
 
-LINUX_ONLY_HEADERS = ['sys/epoll.h']
+LINUX_ONLY_HEADERS = ['sys/epoll.h', 'sys/sendfile.h']
 APPLE_ONLY_HEADERS = ['sys/event.h', 'libkern/OSByteOrder.h', 'machine/endian.h']
 WINDOWS_ONLY_HEADERS = ['WS2tcpip.h', 'WinSock2.h', 'wepoll.h', 'winsock2.h']
 


### PR DESCRIPTION
@matt-42 I am trying to fix macOS builds.  I have not had time to properly test this yet.

I believe this is where the fix should go.  I have modified the single headers by hand and gotten my hello world HTTP server Lithium project to compile on macOS, with Apple Silicon (M1) as the underlying hardware.