### PR TITLE
Use the base path provided in method "add_subapi" for an api path.

### DIFF
--- a/single_headers/lithium_http_server.hh
+++ b/single_headers/lithium_http_server.hh
@@ -3695,7 +3695,9 @@ template <typename Req, typename Resp> struct api {
 
   void add_subapi(std::string prefix, const self& subapi) {
     subapi.routes_map_.for_all_routes([this, prefix](auto r, VH h) {
-      if (!r.empty() && r.back() == '/')
+      if (r.empty() || r == "/")
+        h.url_spec = prefix;
+      else if (r.back() == '/')
         h.url_spec = prefix + r;
       else
         h.url_spec = prefix + '/' + r;


### PR DESCRIPTION
If a subapi is created this will allow to define an endpoint like this very one if desired:

```c++
http_api subapi;
subapi.get("/") = [&](http_request& request, http_response& response) {
	response.write("hello");
};
subapi.get("/world") = [&](http_request &request, http_response &response) {
	response.write("hello world");
};

http_api my_api;
my_api.add_subapi("/hello", &subapi);
```

It allows us to definea method within the subapi route by the subapi itself.